### PR TITLE
Showing total sum in statistics

### DIFF
--- a/shared/helpers/displayMoney.ts
+++ b/shared/helpers/displayMoney.ts
@@ -14,7 +14,7 @@ const defaultParams = {
 };
 
 export const displayMoney = (currency: Currency) => (
-  amount: number | string | undefined | {},
+  amount: number | string | undefined,
   params: Params = defaultParams,
 ) => {
   const actualParams = {

--- a/shared/helpers/displayMoney.ts
+++ b/shared/helpers/displayMoney.ts
@@ -14,7 +14,7 @@ const defaultParams = {
 };
 
 export const displayMoney = (currency: Currency) => (
-  amount: number | string | undefined,
+  amount: number | string | undefined | {},
   params: Params = defaultParams,
 ) => {
   const actualParams = {

--- a/src/features/statistics/features/details/generic/Detail.tsx
+++ b/src/features/statistics/features/details/generic/Detail.tsx
@@ -84,7 +84,7 @@ export const Detail = ({ group, detailType, detailTitle, dataPath }: Props) => {
     if (!lastPeriod) return Option.of(null);
 
     return Option.of(lastPeriod[dataPath]);
-  }, [dataByPeriod]);
+  }, [dataByPeriod, dataPath]);
 
   const errorState = error ? Option.of('Error') : Option.of<string>(null);
 

--- a/src/features/statistics/features/details/generic/Detail.tsx
+++ b/src/features/statistics/features/details/generic/Detail.tsx
@@ -79,7 +79,11 @@ export const Detail = ({ group, detailType, detailTitle, dataPath }: Props) => {
   const total = useMemo(() => {
     if (!dataByPeriod) return Option.of(null);
 
-    return Option.of(head(dataByPeriod) && head(dataByPeriod)[dataPath]);
+    const lastPeriod = Option.of(head(dataByPeriod));
+
+    if (!lastPeriod) return Option.of(null);
+
+    return lastPeriod[dataPath];
   }, [dataByPeriod]);
 
   const errorState = error ? Option.of('Error') : Option.of<string>(null);

--- a/src/features/statistics/features/details/generic/Detail.tsx
+++ b/src/features/statistics/features/details/generic/Detail.tsx
@@ -74,13 +74,17 @@ export const Detail = ({ group, detailType, detailTitle, dataPath }: Props) => {
     [data, dataPath],
   );
 
-  const total = useMemo(
-    () =>
-      Option.of(
-        dataByPeriod && head(dataByPeriod) && head(dataByPeriod)[dataPath],
-      ),
-    [dataByPeriod],
-  );
+  const total = useMemo(() => {
+    if (!dataByPeriod) return null;
+
+    const byMonth = dataByPeriod?.length === 1;
+
+    const totalValue = byMonth
+      ? head(dataByPeriod)[dataPath]
+      : dataByPeriod.reduce((sum, it) => it[dataPath] + sum, 0);
+
+    return Option.of(totalValue);
+  }, [dataByPeriod]);
 
   const errorState = error ? Option.of('Error') : Option.of<string>(null);
 

--- a/src/features/statistics/features/details/generic/Detail.tsx
+++ b/src/features/statistics/features/details/generic/Detail.tsx
@@ -79,7 +79,11 @@ export const Detail = ({ group, detailType, detailTitle, dataPath }: Props) => {
   const total = useMemo(() => {
     if (!dataByPeriod) return Option.of(null);
 
-    return Option.of(head(dataByPeriod) && head(dataByPeriod)[dataPath]);
+    const lastPeriod = head(dataByPeriod);
+
+    if (!lastPeriod) return Option.of(null);
+
+    return Option.of(lastPeriod[dataPath]);
   }, [dataByPeriod]);
 
   const errorState = error ? Option.of('Error') : Option.of<string>(null);


### PR DESCRIPTION
I am really missing the total sum of expenses/incomes on the statistics page. I added it above chart. Looks like this:

![image](https://user-images.githubusercontent.com/22271096/83966763-e955eb80-a8c4-11ea-9689-2602990b9af3.png)


Hope u will consider this slight change.