### PR TITLE
feat(pie_chart): update colors calculation logic

### DIFF
--- a/src/presentation/molecules/pie_chart/pie_chart.tsx
+++ b/src/presentation/molecules/pie_chart/pie_chart.tsx
@@ -21,7 +21,7 @@ export const PieChart = <T extends Record<string, any>>({
       datasets: [
         {
           data: data.map((set) => Number(set[valueKey])),
-          backgroundColor: data.map((set) => colorHash(set[nameKey])),
+          backgroundColor: data.map((_, i) => colorHash(i)),
           borderWidth: 0,
         },
       ],

--- a/src/shared/color.ts
+++ b/src/shared/color.ts
@@ -1,24 +1,41 @@
 import Color from 'color';
 
-/* eslint-disable no-bitwise */
-export function colorHash(input: string | number) {
-  const inputString = input.toString();
+import { getRandomNumber } from './get-random-number';
 
-  let sum = 0;
+enum HexColorTone {
+  Reddish = 'Reddish',
+  Bluish = 'Bluish',
+  Greenish = 'Greenish',
+}
 
-  for (const i of inputString) {
-    sum += i.charCodeAt(0);
+function getRandomHexadecimalNum(): string {
+  const randomNum = getRandomNumber(0, 255);
+  const hexadecimalNum = Math.abs(randomNum).toString(16);
+
+  return hexadecimalNum.length === 1 ? `0${hexadecimalNum}` : hexadecimalNum;
+}
+
+function getRandomHexColor(tone: HexColorTone = HexColorTone.Reddish) {
+  switch (tone) {
+    case HexColorTone.Reddish:
+      return `#FF${getRandomHexadecimalNum()}${getRandomHexadecimalNum()}`;
+    case HexColorTone.Bluish:
+      return `#${getRandomHexadecimalNum()}${getRandomHexadecimalNum()}FF`;
+    case HexColorTone.Greenish:
+      return `#${getRandomHexadecimalNum()}FF${getRandomHexadecimalNum()}`;
+    default:
+      return `#${getRandomHexadecimalNum()}${getRandomHexadecimalNum()}FF`;
   }
+}
 
-  const r = Math.abs(~~(Math.sin(sum + 1) * 256));
-  const g = Math.abs(~~(Math.sin(sum + 2) * 256));
-  const b = Math.abs(~~(Math.sin(sum + 3) * 256));
+export function colorHash(index: number) {
+  let hex =
+    index % 2
+      ? getRandomHexColor(HexColorTone.Reddish)
+      : getRandomHexColor(HexColorTone.Bluish);
 
-  let hex = '#';
-
-  hex += `00${r.toString(16)}`.substr(-2, 2).toUpperCase();
-  hex += `00${g.toString(16)}`.substr(-2, 2).toUpperCase();
-  hex += `00${b.toString(16)}`.substr(-2, 2).toUpperCase();
+  hex =
+    index % 5 || index === 0 ? hex : getRandomHexColor(HexColorTone.Greenish);
 
   return Color(hex).alpha(0.6).string();
 }

--- a/src/shared/get-random-number.ts
+++ b/src/shared/get-random-number.ts
@@ -1,0 +1,3 @@
+export function getRandomNumber(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}


### PR DESCRIPTION
🌵 The problem: all the colors in statistics chart looks very similar
![image](https://user-images.githubusercontent.com/22271096/95663349-3255cf00-0b47-11eb-9d50-0b164bc37e2a.png)

🌈  Solution: I changed the colors calculation logic from one, that depends on the name of category, to another, that depends on index number in data array. That makes the colors more contrasting to each other. Chart looks fancier.

![image](https://user-images.githubusercontent.com/22271096/95663446-0424bf00-0b48-11eb-8f71-4f88bb62c763.png)

Also it make colors unique on every page updation and I'm not sure, how good this solution is. Maybe it will be better if I add more greenish tones.

What do u think?